### PR TITLE
Highlight the link for active page in table of contents (left sidebar)

### DIFF
--- a/src/components/Layout/TableOfContents.jsx
+++ b/src/components/Layout/TableOfContents.jsx
@@ -49,16 +49,14 @@ class TableOfContents extends React.Component {
         let key = `${node.chapter}-${node.lessonNumber}`;
         chapterNumber = `${node.chapter}`;
         chapterLessons.push(
-          <LessonContainer key={key}>
-            <Link to={node.path}>
-              <li>
-                <span>
-                  <p>{node.chapter}.{node.lessonNumber} &nbsp;</p>
-                  <h6>{node.title}</h6>
-                </span>
-              </li>
-            </Link>
-          </LessonContainer>
+          <li key={key}>
+            <StyledLink
+              activeClassName="active"
+              to={node.path}
+            >
+              {node.chapter}.{node.lessonNumber}&nbsp;&nbsp;{node.title}
+            </StyledLink>
+          </li>
         )
       })
       listItems.push(
@@ -94,6 +92,15 @@ const TableOfContentsContainer = styled.div`
     padding: 0;
     margin: 0;
   }
+
+  ul.chapterItems>li {
+    margin: 2px 0;
+  }
+
+  a.active {
+      color: black;
+      font-weight: 700;
+  }
   
   p, h6 {
     display: inline-block;
@@ -107,22 +114,10 @@ const TableOfContentsContainer = styled.div`
   }
 `
 
-const LessonContainer = styled.div`
-  h6, p {
-    color: black;
-    margin: 0;
-    line-height: 1.5;
-  }
-  li {
-    margin: 0;
-  }
-  &:hover {
-    li {
-      span {
-        border-bottom: 1px solid black;
-      }
-    }
-  }
+const StyledLink = styled(Link)`
+  color: black;
+  font-size: 1.6rem;
+  font-weight: lighter;
 `
 
 export default TableOfContents


### PR DESCRIPTION
Hi Alex, thanks for this guide. 

While reading the guide, I noticed one small UI problem. The current page was not highlighted in the link at the table of contents on the left sidebar. When looking at the sidebar, I could not easily see the current page I am reading. 

So, here is the fix. This pull request enables links in the table of content to be a little bolder. 

Let me know what you think about it.